### PR TITLE
Update Socials 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,17 +65,20 @@ theme:
     icon: computer
   feature:
     tabs: true
+  custom_dir: 'theme'
 
 extra:
   social:
     - type: globe
-      link: https://hackathonhackers.eu
+      link: https://hackathons.org.uk
     - type: facebook
       link: https://www.facebook.com/groups/hackathonhackerseu/
     - type: twitter
-      link: https://twitter.com/_HHEU
+      link: https://twitter.com/Hackathons_UK
     - type: github-alt
-      link: https://github.com/hheu
+      link: https://github.com/Hackathons-UK
+    - type: discord
+      link: https://hack.athon.uk/discord
 
 extra_css: 
   - static/css/theme.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,15 +69,15 @@ theme:
 
 extra:
   social:
-    - type: globe
+    - type: fas fa-globe
       link: https://hackathons.org.uk
-    - type: facebook
+    - type: fab fa-facebook-f
       link: https://www.facebook.com/groups/hackathonhackerseu/
-    - type: twitter
+    - type: fab fa-twitter
       link: https://twitter.com/Hackathons_UK
-    - type: github-alt
+    - type: fab fa-github-alt
       link: https://github.com/Hackathons-UK
-    - type: discord
+    - type: fab fa-discord
       link: https://hack.athon.uk/discord
 
 extra_css: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ livereload==2.6.1
 Markdown==3.1.1
 MarkupSafe==1.1.1
 mkdocs==1.0.4
-mkdocs-material==4.4.3
+mkdocs-material==4.6.0
 mkdocs-minify-plugin==0.2.1
 pep562==1.0
 Pygments==2.4.2
-pymdown-extensions==6.1
+pymdown-extensions==6.2.1
 PyYAML==5.1.2
 six==1.12.0
 tornado==6.0.3

--- a/theme/partials/social.html
+++ b/theme/partials/social.html
@@ -1,0 +1,32 @@
+  
+<!--
+  Copyright (c) 2016-2019 Martin Donath <martin.donath@squidfunk.com>
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Social links in footer -->
+{% if config.extra.social %}
+  <div class="md-footer-social">
+    <!-- <link rel="stylesheet" type="text/css"
+        href="{{ 'assets/fonts/font-awesome.css' | url }}" /> -->
+    <script src="https://kit.fontawesome.com/f041df3994.js" crossorigin="anonymous"></script>
+    {% for social in config.extra.social %}
+      <a href="{{ social.link }}" target="_blank" rel="noopener" title="{{ social.type }}" class="md-footer-social__link
+            {{ social.type }}"></a>
+    {% endfor %}
+  </div>
+{% endif %}


### PR DESCRIPTION
We've moved away from the hackathon hackers eu brand. Thus, socials should reflect this.

I also added the Discord, however this required some overriding of the theme. The discord is only in the current version of font-awesome and the latest version of font-awesome is not used in mkdocs-material v4 because it would be a breaking change - squidfunk/mkdocs-material#756. I've overriden the font-awesome install, and the rendering of the social icons in the footer to support the latest version of font-awesome to add Discord. 

We should consider updating to v5 when exits preview.