### PR TITLE
Change University header to Location

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 
 ## Spring 2020
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | Hack the Burgh VI | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | ?? | 29th February-1st March 2020 |
 | IC Health Hack | [ichealthhack.org](https://ichealthhack.org/) | Imperial College London | ?? | 29th February-1st March 2020 |
@@ -52,9 +52,9 @@ This list showcases upcoming UK student-run hackathons and hackathon-associated 
 
 
 ## Autumn 2020
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
-| HackTheMidlands 5.0 | [hackthemidlands.com](https://hackthemidlands.com) | Millennium Point, Curzon St, Birmingham B4 7XG | 300 | Autumn 2020 |
+| HackTheMidlands 5.0 | [hackthemidlands.com](https://hackthemidlands.com) | TBC | 300 | Autumn 2020 |
 | R.U. Hacking? 2020 | [ruhacking.me](https://ruhacking.me) | Reading University | TBC | 24th-25th October 2020 |
 | Hack Brunel 2.0  | [hackbrunel.com](https://hackbrunel.com/) | Brunel University London | 150 | 31st October-1st November 2020 |
 | DurHack 2020    | [durhack.com](https://durhack.com) | Durham University | 425 | 14th-15th November 2020 |
@@ -67,7 +67,7 @@ This list showcases past UK student-run hackathons (most recent first).
 
 ## Spring 2020
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website| Location           |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | JunctionX Exeter | [junctionxexeter.com](https://junctionxexeter.com/) | University of Exeter | 100 | 21st-23rd February 2020 |
 | RGUHack 2020    | [rguhack.uk](https://rguhack.uk)   | Robert Gordon University, Aberdeen | 80 | 22nd-23rd February 2020 |
@@ -83,7 +83,7 @@ This list showcases past UK student-run hackathons (most recent first).
 
 ## Autumn 2019
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website| Location           |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | HackKing's 6.0  | [hackkings.org](https://hackkings.org/) | Kings College London | 150 | 30th November-1st December 2019 |
 | DurHack 2019    | [durhack.com](https://durhack.com) | Durham University | 200 | 23rd-24th November 2019 |
@@ -93,14 +93,14 @@ This list showcases past UK student-run hackathons (most recent first).
 | HackSussex 2019 | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 100 | 9th-10th November 2019 |
 | hackSheffield 5 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 2nd-3rd November 2019 |
 | AstonHack 2019 | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 175 | 2nd-3rd November 2019 |
-| HackTheMidlands 4.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 300 | 26th-27th October 2019 |
+| HackTheMidlands 4.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Birmingham | 300 | 26th-27th October 2019 |
 | HackBrunel | [hackbrunel.com](https://hackbrunel.com/) | Brunel University | 100 | 26th-27th October 2019 |
 | Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | 300 | 18th-20th October 2019 |
 | HHEU Unconference | [hackathonhackers.eu](https://hackathonhackers.eu) | Nottingham University | 25 | 5th October 2019 |
 
 ## Spring 2019
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | 100 | 30th-31st March 2019 |
 | CovHack 19   | [covhack.org](https://covhack.org) | Coventry University | 110 | 16th-17th March 2019 |
@@ -115,7 +115,7 @@ This list showcases past UK student-run hackathons (most recent first).
 
 ## Autumn 2018
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | HackKings v5.0 | [hackkings.org](https://hackkings.org) | King's College London | 200 | 8th-9th December 2018 |
 | HackNotts 2018  | [hacknotts.com](https://www.hacknotts.com)  | University of Nottingham  | 150 | 25th-26th November 2018 |
@@ -126,14 +126,14 @@ This list showcases past UK student-run hackathons (most recent first).
 | GreatUniHack 2018 | [greatunihack.com](https://greatunihack.com/) | University of Manchester | 200 | 10th-11th November 2018 |
 | HackSussex 2018 | [hacksussex.com](https://hacksussex.com/) | University of Sussex | 150 | 10th-11th November 2018 |
 | AstonHack | [astonhack.co.uk](https://astonhack.co.uk/) | Aston University, Birmingham | 150 | 10th-11th November 2018 |
-| HackTheMidlands 3.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Curzon St, Birmingham B4 7XG | 200 | 3rd-4th November 2018 |
+| HackTheMidlands 3.0 | [hackthemidlands.com](https://Hackthemidlands.com/) | Millennium Point, Birmingham | 200 | 3rd-4th November 2018 |
 | hackSheffield 4 | [hacksheffield.co](https://hacksheffield.co/) | University of Sheffield | 200 | 27th-28th October 2018 |
 | Leeds Hackathon | [hackathon.leeds.ac.uk](https://hackathon.leeds.ac.uk/) | University of Leeds | ?? | 26th-28th October 2018 |
 | Do You Have The GUTS? | [gutechsoc.com/hackathon](https://gutechsoc.com/hackathon) | University of Glasgow | ?? | 12th-14th October 2018 |
 
 ## Spring 2018
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | HackSurrey Beta | [beta.hacksurrey.uk](https://beta.hacksurrey.uk/) | University of Surrey | 100 | 5th-6th May 2018 |
 | StudentHack VI | N/A | Manchester | 150 | 28th-29th April 2018 |
@@ -153,7 +153,7 @@ This list showcases past UK student-run hackathons (most recent first).
 
 ## Autumn 2017
 
-|Hackathon        |Website| University         |No. of Hackers|Date|
+|Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | DurHack 2017 | [durhack.com](http://durhack.com) | Durham University | 100 | 9th-10th December 2017 |
 | Sex Tech Hack II | [sexhack.tech](https://sexhack.tech) | Goldsmiths, University of London | 100 | 25th-26th November 2017 | 


### PR DESCRIPTION
Not all student hackathons are associated with universities.

HackTheMidlands isn’t associated with a university, but does receive support from the University of Birmingham. As a result, the University heading is a little misleading as it just has our venue. I renamed the header to Location, with the intention that others keep putting their universities in the column (maybe we make a contributing guide), and those like HTM can put their venue.