### PR TITLE
Update number of hackers at Edinburgh events

### DIFF
--- a/docs/events/list.md
+++ b/docs/events/list.md
@@ -8,7 +8,7 @@ Want to add something to this list? [Fork and pull request](https://github.com/H
 |Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | StacsHack 2020 | [Facebook event](https://www.facebook.com/events/950732241970896/) | University of St Andrews | ?? | 7th-8th March 2020 |
-| CreatED Hack '20 | [createdhack.com](https://createdhack.com/) | University of Edinburgh | 200 | 14th-15th March 2020 |
+| CreatED Hack '20 | [createdhack.com](https://createdhack.com/) | University of Edinburgh | 110 | 14th-15th March 2020 |
 | HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | ?? |  14th-15th March 2020 |
 | HackThePlug   | [hacktheplug.tech](https://hacktheplug.tech/) | University of Bath | ?? |  28th-29th March 2020 |
 | Hackathons UK Unconference | TBC |  Manchester Metropolitan University  | ~50 | 4th April 2020 |

--- a/docs/events/list.md
+++ b/docs/events/list.md
@@ -35,7 +35,7 @@ This list showcases past UK student-run hackathons (most recent first).
 
 |Hackathon        |Website| University         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
-| Hack the Burgh VI | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | 240 | 29th February-1st March 2020 |
+| Hack the Burgh VI | [hacktheburgh.com](https://2020.hacktheburgh.com/) | University of Edinburgh | 200 | 29th February-1st March 2020 |
 | IC Health Hack | [ichealthhack.org](https://ichealthhack.org/) | Imperial College London | ?? | 29th February-1st March 2020 |
 | AI Hack 2020 | [aihack.org](https://aihack.org/) | Imperial College London | ?? | 29th February-1st March 2020 |
 | Hack Keele | [Facebook post](https://www.facebook.com/hackkeele/posts/2571192316537510) | Keele University | ?? | 29th February 2020 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Want to add something to this list? [Fork and pull request](https://github.com/H
 |Hackathon        |Website|   Location         |No. of Hackers|Date|
 |-----------------|-------|--------------------|--------------|----|
 | StacsHack 2020 | [Facebook event](https://www.facebook.com/events/950732241970896/) | University of St Andrews | ?? | 7th-8th March 2020 |
-| CreatED Hack '20 | [createdhack.com](https://createdhack.com/) | University of Edinburgh | 200 | 14th-15th March 2020 |
+| CreatED Hack '20 | [createdhack.com](https://createdhack.com/) | University of Edinburgh | 110 | 14th-15th March 2020 |
 | HackMed   | [hackmed.uk](http://hackmed.uk/) | University of Sheffield | ?? |  14th-15th March 2020 |
 | HackThePlug   | [hacktheplug.tech](https://hacktheplug.tech/) | University of Bath | ?? |  28th-29th March 2020 |
 | Hackathons UK Unconference | TBC |  Manchester Metropolitan University  | ~50 | 4th April 2020 |


### PR DESCRIPTION
Update the turnout of hackers at Hack the Burgh VI to 200.

Update the target number of hackers for CreatED Hack '20 to 110.