### PR TITLE
updated events list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,11 +35,6 @@ Want to add something to this list? [Fork and pull request](https://github.com/H
 |-----------------|-------|--------------------|--------------|----|
 | STEAM AiHack | [hack.innovationfest.co.uk/AiHack/](https://hack.innovationfest.co.uk/AiHack/) | Birmingham (Online) | 100 | 27th-31st July 2020
 
-## Spring 2020
-
-|Hackathon        |Website|   Location         |No. of Hackers|Date|
-|-----------------|-------|--------------------|--------------|----|
-| DurHack:NextGen  | [durhack.com/nextgen](https://durhack.com/nextgen) | Durham University | 100 (U18 only!) | TBC |
 
 ## Autumn 2020
 |Hackathon        |Website|   Location         |No. of Hackers|Date|


### PR DESCRIPTION
Removed an event from the active events list which has been postponed (with no date to run), personally reckon this list is most useful when containing hacks that are still scheduled to happen!