### PR TITLE
[NO-JIRA] Removed Orphaned Home Page 🍰

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: UK Hackathons
 site_url: https://hack.athon.uk/
 
 nav:
-  - Home: 'index.md'
   - Community:
     - Index: 'index.md'
     - Art: 'art/index.md'


### PR DESCRIPTION
This PR removed the orphaned home page from the navigation menu. Both the community page and the home page go to the same page (index.md), as the community page is the home page pressing home will not take you anywhere and could potentially be confusing to the user :) 

Before:
![image](https://user-images.githubusercontent.com/6086266/87874234-13202900-c9c0-11ea-8a69-f108bcafc522.png)
The `home` page can never be highlighted as the selected page as it is the community page


After:
![image](https://user-images.githubusercontent.com/6086266/87874225-026fb300-c9c0-11ea-9033-c1666afd3be2.png)



# :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: 