### PR TITLE
Add Birmingham Open Hack

### DIFF
--- a/events.yml
+++ b/events.yml
@@ -21,6 +21,13 @@ extra:
     - name: Autumn 2020
       past: false
       hackathons:
+        - name: Birmingham Open Hack 
+          website: https://boh.innovationfest.co.uk/
+          location: Birmingham (Online)
+          when: 16th-18th October
+          attendees: 100
+          all_ages: true
+          digital: true
         - name: HackTheMidlands 5.0
           background: /static/art/hackathon_tiles/htm_2020_background.png
           logo: /static/art/hackathon_tiles/htm_2020_logo.jpg


### PR DESCRIPTION
**Added Event:** Birmingham Open Hack

**Event Description:** 
Birmingham Open Hack is a hackathon open to everyone with a primary focus on empowering the incoming youth of the tech industry. This is a youth-oriented innovation opportunity for them to showcase their skills and also learn new skills. 
Powered by STEAM Hacks, this hackathon enables the growing talent and tech enthusiasts alike to take on challenges, win prizes, learn new skills and get an insight to the Birmingham tech scene from industry professionals.
Birmingham Open Hack is community-oriented opportunity that allows you to grow, innovate and connect with Birmingham’s international business network. Also we've partnered with Birmingham Tech Week!